### PR TITLE
fix setup.py and setup namespace imports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,9 @@ except ImportError:
     print("warning: pypandoc module not found, could not convert Markdown to RST")
     long_description = ''
 
+with open('requirements.txt') as f:
+    required = f.read().splitlines()
+
 setup(
     name='wextractor',
     url='https://github.com/codeforamerica/w-drive-extractor',
@@ -22,11 +25,8 @@ setup(
     description='Extract flat data and load it as relational data',
     long_description=long_description,
 
-    packages=find_packages(exclude=['test*']),
-    install_requires=[
-        'psycopg2>=2.5.0',
-        'xlrd>=0.9.3'
-    ],
+    packages=find_packages(),
+    install_requires=required,
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Programming Language :: Python :: 2',

--- a/wextractor/extractors/__init__.py
+++ b/wextractor/extractors/__init__.py
@@ -1,1 +1,3 @@
 #!/usr/bin/env python
+from extractor import Extractor
+from excel import ExcelExtractor

--- a/wextractor/loaders/__init__.py
+++ b/wextractor/loaders/__init__.py
@@ -1,1 +1,3 @@
 #!/usr/bin/env python
+from loader import Loader
+from postgres import PostgresLoader


### PR DESCRIPTION
This ensures that more packages you add will be found by setup.

I also made `requirements.txt` the main authority on dependencies by opening it in setup.py for the `install_requires` directive.

Also, I added public namespace includes so you can do stuff like:

```
from wextractor.extractors import ExcelExtractor
from wextractor.loaders import PostgresLoader
```

You could do similar in the top-level `__init__.py` if you want to be able to import from the flat namespace.
